### PR TITLE
Enable notification of global keys being released.

### DIFF
--- a/atom/browser/api/atom_api_global_shortcut.h
+++ b/atom/browser/api/atom_api_global_shortcut.h
@@ -23,6 +23,8 @@ class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
  public:
   static mate::Handle<GlobalShortcut> Create(v8::Isolate* isolate);
 
+  typedef base::Callback<v8::Handle<v8::Value>(const bool)> KeyEventHandler;
+
  protected:
   GlobalShortcut();
   virtual ~GlobalShortcut();
@@ -32,18 +34,22 @@ class GlobalShortcut : public extensions::GlobalShortcutListener::Observer,
       v8::Isolate* isolate) override;
 
  private:
-  typedef std::map<ui::Accelerator, base::Closure> AcceleratorCallbackMap;
+  typedef std::map<ui::Accelerator, KeyEventHandler> AcceleratorCallbackMap;
 
   bool Register(const ui::Accelerator& accelerator,
-                const base::Closure& callback);
+                const KeyEventHandler& callback);
+  bool RegisterWithRelease(const ui::Accelerator& accelerator,
+                           const KeyEventHandler& callback);
   bool IsRegistered(const ui::Accelerator& accelerator);
   void Unregister(const ui::Accelerator& accelerator);
   void UnregisterAll();
 
   // GlobalShortcutListener::Observer implementation.
   void OnKeyPressed(const ui::Accelerator& accelerator) override;
+  void OnKeyReleased(const ui::Accelerator& accelerator) override;
 
   AcceleratorCallbackMap accelerator_callback_map_;
+  AcceleratorCallbackMap accelerator_released_callback_map_;
 
   DISALLOW_COPY_AND_ASSIGN(GlobalShortcut);
 };

--- a/chromium_src/chrome/browser/extensions/global_shortcut_listener.cc
+++ b/chromium_src/chrome/browser/extensions/global_shortcut_listener.cc
@@ -119,4 +119,17 @@ void GlobalShortcutListener::NotifyKeyPressed(
   iter->second->OnKeyPressed(accelerator);
 }
 
+void GlobalShortcutListener::NotifyKeyReleased(
+    const ui::Accelerator& accelerator) {
+  AcceleratorMap::iterator iter = accelerator_map_.find(accelerator);
+  if (iter == accelerator_map_.end()) {
+    // This should never occur, because if it does, we have failed to unregister
+    // or failed to clean up the map after unregistering the shortcut.
+    NOTREACHED();
+    return;  // No-one is listening to this key.
+  }
+
+  iter->second->OnKeyReleased(accelerator);
+}
+
 }  // namespace extensions

--- a/chromium_src/chrome/browser/extensions/global_shortcut_listener.h
+++ b/chromium_src/chrome/browser/extensions/global_shortcut_listener.h
@@ -25,6 +25,7 @@ class GlobalShortcutListener {
    public:
     // Called when your global shortcut (|accelerator|) is struck.
     virtual void OnKeyPressed(const ui::Accelerator& accelerator) = 0;
+    virtual void OnKeyReleased(const ui::Accelerator& accelerator) = 0;
   };
 
   virtual ~GlobalShortcutListener();
@@ -65,6 +66,7 @@ class GlobalShortcutListener {
   // Called by platform specific implementations of this class whenever a key
   // is struck. Only called for keys that have an observer registered.
   void NotifyKeyPressed(const ui::Accelerator& accelerator);
+  void NotifyKeyReleased(const ui::Accelerator& accelerator);
 
  private:
   // The following methods are implemented by platform-specific implementations

--- a/chromium_src/chrome/browser/extensions/global_shortcut_listener_mac.h
+++ b/chromium_src/chrome/browser/extensions/global_shortcut_listener_mac.h
@@ -37,8 +37,8 @@ class GlobalShortcutListenerMac : public GlobalShortcutListener {
   typedef std::map<KeyId, EventHotKeyRef> IdHotKeyRefMap;
 
   // Keyboard event callbacks.
-  void OnHotKeyEvent(EventHotKeyID hot_key_id);
-  bool OnMediaOrVolumeKeyEvent(int key_code);
+  void OnHotKeyEvent(EventHotKeyID hot_key_id, bool is_pressed);
+  bool OnMediaOrVolumeKeyEvent(int key_code, bool is_pressed);
 
   // GlobalShortcutListener implementation.
   virtual void StartListening() override;
@@ -71,7 +71,9 @@ class GlobalShortcutListenerMac : public GlobalShortcutListener {
       CGEventTapProxy proxy, CGEventType type, CGEventRef event, void* refcon);
 
   // The callback for when a hot key event happens.
-  static OSStatus HotKeyHandler(
+  static OSStatus HotKeyPressedHandler(
+      EventHandlerCallRef next_handler, EventRef event, void* user_data);
+  static OSStatus HotKeyReleasedHandler(
       EventHandlerCallRef next_handler, EventRef event, void* user_data);
 
   // Whether this object is listening for global shortcuts.


### PR DESCRIPTION
Note: Only works on Mac OS, and adds a previously non-existent argument to the key pressed callback indicating whether the keys are currently being pressed.
